### PR TITLE
Adding QuickSummon

### DIFF
--- a/Assets/CK-QOL/Entry.cs
+++ b/Assets/CK-QOL/Entry.cs
@@ -8,6 +8,7 @@ using CK_QOL.Features.NoDeathPenalty;
 using CK_QOL.Features.NoEquipmentDurabilityLoss;
 using CK_QOL.Features.QuickEat;
 using CK_QOL.Features.QuickHeal;
+using CK_QOL.Features.QuickSummon;
 using CK_QOL.Features.QuickStash;
 using CoreLib;
 using CoreLib.Localization;
@@ -21,9 +22,10 @@ namespace CK_QOL
 {
 	public class Entry : IMod
 	{
-		private readonly List<IFeature> _features = new();
 		internal static LoadedMod ModInfo { get; private set; }
 		internal static Player RewiredPlayer { get; private set; }
+		
+		private readonly List<IFeature> _features = new();
 
 		#region IMod
 
@@ -44,9 +46,9 @@ namespace CK_QOL
 			CoreLibMod.LoadModule(typeof(RewiredExtensionModule));
 
 			RewiredExtensionModule.rewiredStart += () => RewiredPlayer = ReInput.players.GetPlayer(0);
-
+			
 			ModLogger.Info("Loading features..");
-
+			
 			_features.AddRange(new IFeature[]
 			{
 				CraftingRange.Instance,
@@ -55,14 +57,16 @@ namespace CK_QOL
 				NoDeathPenalty.Instance,
 				NoEquipmentDurabilityLoss.Instance,
 				QuickHeal.Instance,
-				QuickEat.Instance
+				QuickEat.Instance,
+				QuickSummon.Instance
 			});
 
 			foreach (var feature in _features.OrderBy(feature => feature.IsEnabled))
 			{
 				ModLogger.Info($"{feature.DisplayName} ({feature.FeatureType})");
-
+                
 				if (feature.IsEnabled)
+				{
 					switch (feature)
 					{
 						case CraftingRange { IsEnabled: true } craftingRange:
@@ -77,10 +81,10 @@ namespace CK_QOL
 							ModLogger.Info($"{nameof(itemPickUpNotifier.AggregateDelay)}: {itemPickUpNotifier.AggregateDelay}");
 							break;
 						case NoDeathPenalty { IsEnabled: true } noDeathPenalty:
-							ModLogger.Info("No configuration available.");
+							ModLogger.Info($"{feature.DisplayName}");
 							break;
 						case NoEquipmentDurabilityLoss { IsEnabled: true } noEquipmentDurabilityLoss:
-							ModLogger.Info("No configuration available.");
+							ModLogger.Info($"{feature.DisplayName}");
 							break;
 						case QuickHeal { IsEnabled: true } quickHeal:
 							ModLogger.Info($"{nameof(quickHeal.EquipmentSlotIndex)}: {quickHeal.EquipmentSlotIndex}");
@@ -88,11 +92,17 @@ namespace CK_QOL
 						case QuickEat { IsEnabled: true } quickEat:
 							ModLogger.Info($"{nameof(quickEat.EquipmentSlotIndex)}: {quickEat.EquipmentSlotIndex}");
 							break;
+						case QuickSummon { IsEnabled: true } quickSummon:
+							ModLogger.Info($"{nameof(quickSummon.EquipmentSlotIndex)}: {quickSummon.EquipmentSlotIndex}");
+							break;
 					}
+				}
 				else
+				{
 					ModLogger.Warn("Feature is disabled.");
+				}
 			}
-
+			
 			ModLogger.Info(".. all features loaded.");
 		}
 

--- a/Assets/CK-QOL/Features/QuickSummon.meta
+++ b/Assets/CK-QOL/Features/QuickSummon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b1802a7326d97b4080520e21064715b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CK-QOL/Features/QuickSummon/QuickSummon.cs
+++ b/Assets/CK-QOL/Features/QuickSummon/QuickSummon.cs
@@ -1,0 +1,181 @@
+using CK_QOL.Core;
+using CK_QOL.Core.Config;
+using CK_QOL.Core.Features;
+using CoreLib.RewiredExtension;
+using Rewired;
+
+namespace CK_QOL.Features.QuickSummon
+{
+    /// <summary>
+    ///     Represents the "Quick Summon" feature, allowing players to quickly equip the "Tome of the Dark" 
+    ///     use a summon spell, and swap back to the previously equipped item.
+    ///     At Some point, will work out how to handle the other 2 summoning books.
+    /// </summary>
+    internal sealed class QuickSummon : FeatureBase<QuickSummon>
+    {
+        private int _fromSlotIndex = -1;
+        private int _previousSlotIndex = -1;
+
+        public QuickSummon()
+        {
+            ApplyConfigurations();
+            ApplyKeyBinds();
+        }
+
+        public override bool CanExecute()
+        {
+            return base.CanExecute()
+                   && Entry.RewiredPlayer != null
+                   && Manager.main.player != null
+                   && !(Manager.input?.textInputIsActive ?? false);
+        }
+
+        public override void Execute()
+        {
+            if (!CanExecute())
+            {
+                return;
+            }
+
+            var player = Manager.main.player;
+
+            if (TryFindSummonTome(player))
+            {
+                CastSummonSpell(player);
+            }
+        }
+
+        public override void Update()
+        {
+            if (!CanExecute())
+            {
+                return;
+            }
+
+            if (Entry.RewiredPlayer.GetButtonDown(KeyBindName))
+            {
+                Execute();
+            }
+
+            if (Entry.RewiredPlayer.GetButtonUp(KeyBindName))
+            {
+                SwapBackToPreviousSlot();
+            }
+        }
+
+        /// <summary>
+        ///     Attempts to find the "Tome of the Dark" in the player's inventory.
+        /// </summary>
+        /// <param name="player">The player controller to access inventory.</param>
+        /// <returns>
+        ///     <see langword="true" /> if the tome is found; otherwise, <see langword="false" />.
+        /// </returns>
+        private bool TryFindSummonTome(PlayerController player)
+        {
+            _previousSlotIndex = player.equippedSlotIndex;
+            _fromSlotIndex = -1;
+
+            // Check if the Tome of the Dark is in the predefined slot.
+            if (IsSummonTome(player.playerInventoryHandler.GetObjectData(EquipmentSlotIndex)))
+            {
+                return true;
+            }
+
+            // Look through the inventory if not in the predefined slot.
+            var playerInventorySize = player.playerInventoryHandler.size;
+            for (var playerInventoryIndex = 0; playerInventoryIndex < playerInventorySize; playerInventoryIndex++)
+            {
+                if (!IsSummonTome(player.playerInventoryHandler.GetObjectData(playerInventoryIndex)))
+                {
+                    continue;
+                }
+
+                _fromSlotIndex = playerInventoryIndex; // Store the slot with the Tome of the Dark.
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Checks if the provided object data corresponds to the "Tome of the Dark".
+        /// </summary>
+        /// <param name="objectData">The object data to check.</param>
+        /// <returns>
+        ///     <see langword="true" /> if the object is the summon tome; otherwise, <see langword="false" />.
+        /// </returns>
+private static bool IsSummonTome(ObjectDataCD objectData)
+{
+    return objectData.objectID == ObjectID.TomeOfRange; // Using TomeOfRange as the correct ID
+}
+
+
+        /// <summary>
+        ///     Equips the "Tome of the Dark", uses the summon spell, and swaps back to the previous item.
+        /// </summary>
+        /// <param name="player">The player controller.</param>
+        private void CastSummonSpell(PlayerController player)
+        {
+            // Equip the Tome of the Dark to the designated slot.
+            player.playerInventoryHandler.Swap(player, _fromSlotIndex, player.playerInventoryHandler, EquipmentSlotIndex);
+            player.EquipSlot(EquipmentSlotIndex);
+
+            // Trigger the summon spell action.
+            var inputHistory = EntityUtility.GetComponentData<ClientInputHistoryCD>(player.entity, player.world);
+            inputHistory.secondInteractUITriggered = false;
+            EntityUtility.SetComponentData(player.entity, player.world, inputHistory);
+
+            // Re-equip the slot to ensure proper spell activation.
+            player.EquipSlot(EquipmentSlotIndex);
+            inputHistory.secondInteractUITriggered = true;
+            EntityUtility.SetComponentData(player.entity, player.world, inputHistory);
+
+            // Swap back to the original item.
+            if (_fromSlotIndex != -1 && player.playerInventoryHandler.GetObjectData(_fromSlotIndex).objectID != ObjectID.None)
+            {
+                player.playerInventoryHandler.Swap(player, _fromSlotIndex, player.playerInventoryHandler, EquipmentSlotIndex);
+            }
+        }
+
+        /// <summary>
+        ///     Swaps back to the previously equipped slot after using the summon spell.
+        /// </summary>
+        private void SwapBackToPreviousSlot()
+        {
+            if (_previousSlotIndex == -1)
+            {
+                return;
+            }
+
+            Manager.main.player.EquipSlot(_previousSlotIndex);
+        }
+
+        #region IFeature
+
+        public override string Name => nameof(QuickSummon);
+        public override string DisplayName => "Quick Summon";
+        public override string Description => "Quickly equips 'Tome of the Dark', casts a summon spell, and swaps back to the previous item.";
+        public override FeatureType FeatureType => FeatureType.Client;
+
+        #endregion IFeature
+
+        #region Configurations
+
+        internal string KeyBindName => $"{ModSettings.ShortName}_{Name}";
+        internal int EquipmentSlotIndex { get; private set; }
+
+        private void ApplyConfigurations()
+        {
+            ConfigBase.Create(this);
+            IsEnabled = QuickSummonConfig.ApplyIsEnabled(this);
+            EquipmentSlotIndex = QuickSummonConfig.ApplyEquipmentSlotIndex(this);
+        }
+
+        private void ApplyKeyBinds()
+        {
+            RewiredExtensionModule.AddKeybind(KeyBindName, "Quick Summon", KeyboardKeyCode.X);
+        }
+
+        #endregion Configurations
+    }
+}

--- a/Assets/CK-QOL/Features/QuickSummon/QuickSummon.cs.meta
+++ b/Assets/CK-QOL/Features/QuickSummon/QuickSummon.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f55c107c10d34942b684939c33f2d9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CK-QOL/Features/QuickSummon/QuickSummonConfig.cs
+++ b/Assets/CK-QOL/Features/QuickSummon/QuickSummonConfig.cs
@@ -1,0 +1,31 @@
+using System.Diagnostics.CodeAnalysis;
+using CK_QOL.Core.Config;
+using CK_QOL.Core.Features;
+using CoreLib.Data.Configuration;
+
+namespace CK_QOL.Features.QuickSummon
+{
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+    internal sealed class QuickSummonConfig : ConfigBase
+    {
+        internal static bool ApplyIsEnabled(IFeature feature)
+        {
+            var acceptableValues = new AcceptableValueList<bool>(true, false);
+            var description = new ConfigDescription($"Enable the '{feature.DisplayName}' ({feature.FeatureType}) feature? {feature.Description}", acceptableValues);
+            var definition = new ConfigDefinition(feature.Name, nameof(feature.IsEnabled));
+            var entry = Config.Bind(definition, true, description);
+
+            return entry.Value;
+        }
+
+        internal static int ApplyEquipmentSlotIndex(QuickSummon feature)
+        {
+            var acceptableValues = new AcceptableValueRange<int>(0, 9);
+            var description = new ConfigDescription("Set the summoning tome slot index. It's the count/number of the slot minus 1.", acceptableValues);
+            var definition = new ConfigDefinition(feature.Name, nameof(feature.EquipmentSlotIndex));
+            var entry = Config.Bind(definition, 0, description);
+
+            return entry.Value;
+        }
+    }
+}

--- a/Assets/CK-QOL/Features/QuickSummon/QuickSummonConfig.cs.meta
+++ b/Assets/CK-QOL/Features/QuickSummon/QuickSummonConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a98193d657e72554fa10ebb821570a5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
So this will Summon 1 minion per key press X, It will swap the book on your bar and back off on slot 0  and keep what ever you had selected.

Most the time you have to hold it for 1 sec or 2 before it will summon.

I have tried adding swap delay timers and such to all most fix it but it got complicated so I'm just doing this for now unless someone else can fix it :P

- Updated the logging message for the NoEquipmentDurabilityLoss and NoDeathPenalty feature to include the actual display name instead of a generic message.

This logs the DisplayName of the feature, which could be useful if you have different names for various features or want to be more descriptive in the log. It's dynamic and can provide more detailed context about what feature is being processed.